### PR TITLE
Add fallback url

### DIFF
--- a/DataGetter.cs
+++ b/DataGetter.cs
@@ -11,8 +11,10 @@ namespace SongDetailsCache {
 	static class DataGetter {
 		public static readonly IReadOnlyDictionary<string, string> dataSources = new Dictionary<string, string>() {
 			{ "Direct", "https://raw.githubusercontent.com/andruzzzhka/BeatSaberScrappedData/master/songDetails2.gz" },
-			// Caches stuff for 12 hours, but at least its a way to get the data at all for people behind China Firewall
-			{ "JSDelivr", "https://cdn.jsdelivr.net/gh/andruzzzhka/BeatSaberScrappedData/songDetails2.gz" }
+			// Caches stuff for 12 hours as backup
+			{ "JSDelivr", "https://cdn.jsdelivr.net/gh/andruzzzhka/BeatSaberScrappedData/songDetails2.gz" },
+			// Caches stuff for 5 hours, bandwidth 512KB/s, but at least its a way to get the data at all for people behind China Firewall
+			{ "WGzeyu", "https://beatmods.gtxcn.com/github/BeatSaberScrappedData/songDetails2.gz" }
 		};
 
 		//const string dataUrl = "http://127.0.0.1/SongDetailsCache.proto.gz";


### PR DESCRIPTION
jsDelivr lost their ICP filing in China yesterday and has been unable to provide services using servers in mainland China, and has now switched to servers near China, which are still available but no longer reliable.
https://github.com/jsdelivr/jsdelivr/issues/18348#issuecomment-997777996
I added BeatSaberScrappedData reverse proxy to my server, which is a mainland China server with ICP filing and can provide service reliably in China, except that the bandwidth is only 512KB/s.
This server has been providing BeatMods reverse proxy for [beatmods-top/ModAssistant](https://github.com/beatmods-top/ModAssistant) and has been running for over a year.