### PR TITLE
Change fallback url

### DIFF
--- a/DataGetter.cs
+++ b/DataGetter.cs
@@ -14,7 +14,7 @@ namespace SongDetailsCache {
 			// Caches stuff for 12 hours as backup
 			{ "JSDelivr", ("https://cdn.jsdelivr.net/gh/andruzzzhka/BeatSaberScrappedData/songDetails2.gz", TimeSpan.FromSeconds(25)) },
 			// Caches stuff for 5 hours, bandwidth 512KB/s, but at least its a way to get the data at all for people behind China Firewall
-			{ "WGzeyu", ("https://beatmods.gtxcn.com/github/BeatSaberScrappedData/songDetails2.gz", TimeSpan.FromSeconds(50)) }
+			{ "WGzeyu", ("https://beatmods.wgzeyu.com/github/BeatSaberScrappedData/songDetails2.gz", TimeSpan.FromSeconds(50)) }
 		};
 
 		//const string dataUrl = "http://127.0.0.1/SongDetailsCache.proto.gz";


### PR DESCRIPTION
The domain name that had previously been filed through ICP was suddenly block by a department in Hebei Province, China a few days ago on the grounds of anti-fraud, resulting in the inability to access within Hebei Province, to appeal must have corporate qualifications, so I decided to change the domain name, no longer filed, so will no longer be able to use the server in mainland China, I will use a server near China to ensure the speed of access in China.