### PR TITLE
Update map rating calculation

### DIFF
--- a/Structs/SongProto.cs
+++ b/Structs/SongProto.cs
@@ -78,13 +78,11 @@ namespace SongDetailsCache.Structs {
 		/// </summary>
 		public float rating {
 			get {
-				float tot = upvotes + downvotes;
-				if(tot == 0)
-					return 0;
+				double total = upvotes + downvotes;
 
-				var tmp = upvotes / tot;
+				var score = upvotes / total;
 
-				return (float)(tmp - (tmp - 0.5) * Math.Pow(2, -Math.Log10(tot + 1)));
+				return (float)(score - ((score - 0.5) * Math.Pow(2, -Math.Log((total / 2) + 1, 3))));
 			}
 		}
 


### PR DESCRIPTION
The existing calculation is outdated (added in 2021 according to git blame).
The new formula is from the BeatSaver faq (posted in 2023)
See: [Discord Message](https://discord.com/channels/882730837974609940/884596378238599168/1107864528617750619) and [Desmos Graph](https://www.desmos.com/calculator/jiafmaznwi)
![image](https://github.com/user-attachments/assets/62ab79a9-6771-4472-9d37-b6438b9a941f)
